### PR TITLE
Fix xattr support on linux

### DIFF
--- a/context.go
+++ b/context.go
@@ -204,7 +204,7 @@ func (c *Context) resolveXAttrs(fp string, fi os.FileInfo, base *resource) (map[
 	// symlinks is slightly questionable, since their support is spotty on
 	// most file systems and xattrs are generally stored in the inode. This
 	// may belong elsewhere.
-	if !(fi.Mode().IsRegular() || fi.Mode().IsDir() || fi.Mode()&os.ModeSymlink != 0) {
+	if !(fi.Mode().IsRegular() || fi.Mode().IsDir()) {
 		return nil, nil
 	}
 

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -9,7 +9,7 @@ import (
 // hardlinkKey provides a tuple-key for managing hardlinks. This is system-
 // specific.
 type hardlinkKey struct {
-	dev   int32
+	dev   uint64
 	inode uint64
 }
 

--- a/xattr.go
+++ b/xattr.go
@@ -49,7 +49,7 @@ func Listxattr(path string) ([]string, error) {
 func Getxattr(path, attr string) ([]byte, error) {
 	var p []byte = make([]byte, defaultXattrBufferSize)
 	for {
-		n, err := getxattr(path, attr, p, XATTR_NOFOLLOW)
+		n, err := getxattr(path, attr, p)
 		if err != nil {
 			if errno, ok := err.(syscall.Errno); ok && errno == syscall.ERANGE {
 				p = make([]byte, len(p)*2) // this can't be ideal.

--- a/xattrs_linux.go
+++ b/xattrs_linux.go
@@ -7,7 +7,7 @@ func getxattr(path string, attr string, dest []byte) (sz int, err error) {
 }
 
 func listxattr(path string, dest []byte, flags int) (sz int, err error) {
-	return unix.Listxattr(path, dest, flags)
+	return unix.Listxattr(path, dest)
 }
 
 func removexattr(path string, attr string) (err error) {


### PR DESCRIPTION
Remove support for xattr on symbolic links due to lack of syscall support in golang system package.


Correct xattr support on symlinks requires support for the `llistxattr` syscall. Since this is currently missing is makes sense to remove support for xattr on symlinks, as already questioned by the comment above it.