### PR TITLE
Fix context constructor name

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -22,7 +22,7 @@ var (
 				log.Fatalln("please specify a root")
 			}
 
-			ctx, err := continuity.NewPathContext(args[0])
+			ctx, err := continuity.NewContext(args[0])
 			if err != nil {
 				log.Fatalf("error creating path context: %v", err)
 			}

--- a/context.go
+++ b/context.go
@@ -37,7 +37,7 @@ type context struct {
 }
 
 // NewContext returns a Context associated with root.
-func NewPathContext(root string) (Context, error) {
+func NewContext(root string) (Context, error) {
 	// normalize to absolute path
 	root, err := filepath.Abs(filepath.Clean(root))
 	if err != nil {


### PR DESCRIPTION
Keep original name for compatibility with simplest and most common use case
