### PR TITLE
Import sha256 to avoid panic from digest package

### DIFF
--- a/cmd/continuity/main.go
+++ b/cmd/continuity/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "crypto/sha256"
+
 	"github.com/stevvooe/continuity/commands"
 )
 


### PR DESCRIPTION
Digest package used to panic with nil pointer exception but now has an explicit panic. This explicit import will allow continuity with the latest digest package version.