### PR TITLE
Skip chmod on symlinks

### DIFF
--- a/context.go
+++ b/context.go
@@ -286,6 +286,7 @@ func (c *context) Apply(resource Resource) error {
 		return err
 	}
 
+	var chmod = true
 	var exists bool
 	if _, err := c.driver.Lstat(fp); err != nil {
 		if !os.IsNotExist(err) {
@@ -346,14 +347,16 @@ func (c *context) Apply(resource Resource) error {
 			if err := c.driver.Symlink(target, fp); err != nil {
 				return err
 			}
-			if err := c.driver.Lchmod(fp, resource.Mode()); err != nil {
-				return err
-			}
+			// Not supported on linux, skip chmod on links
+			//if err := c.driver.Lchmod(fp, resource.Mode()); err != nil {
+			//	return err
+			//}
 		}
+		chmod = false
 	}
 
 	// Update filemode if file was not created
-	if exists {
+	if chmod && exists {
 		if err := c.driver.Lchmod(fp, resource.Mode()); err != nil {
 			return err
 		}


### PR DESCRIPTION
No follow for chmod on symlinks is currently not implemented in the linux kernel. Skip to prevent unintended chmod on targets.