### PR TITLE
apply: correct handling of symlinks

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -127,7 +127,7 @@ func (d *driver) Lchown(name, uidStr, gidStr string) error {
 	if err != nil {
 		return err
 	}
-	gid, err := strconv.Atoi(uidStr)
+	gid, err := strconv.Atoi(gidStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, tricky things were attempted with symlinks to make filesystems more
portable. Without operating system support, this effort was wasted and caused
bugs. Code attempting to fixup symlinks has been elided in favor of simply
transporting the link targets as is.

A small bug in lchown was fixed, as well.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @dmcgowan @dmcgowan 