### PR TITLE
Add support for applying and verifying devices and named pipes

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1,6 +1,7 @@
 package continuity
 
 import (
+	"errors"
 	"os"
 	"strconv"
 )
@@ -27,6 +28,11 @@ type Driver interface {
 	Lchmod(path string, mode os.FileMode) error
 	Lchown(path, uid, gid string) error
 	Symlink(oldname, newname string) error
+
+	// TODO(aaronl): These methods might move outside the main Driver
+	// interface in the future as more platforms are added.
+	Mknod(path string, mode os.FileMode, major int, minor int) error
+	Mkfifo(path string, mode os.FileMode) error
 
 	// NOTE(stevvooe): We may want to actually include the path manipulation
 	// functions here, as well. They have been listed below to make the
@@ -136,4 +142,17 @@ func (d *driver) Lchown(name, uidStr, gidStr string) error {
 
 func (d *driver) Symlink(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
+}
+
+func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
+	return mknod(path, mode, major, minor)
+}
+
+func (d *driver) Mkfifo(path string, mode os.FileMode) error {
+	if mode&os.ModeNamedPipe == 0 {
+		return errors.New("mode passed to Mkfifo does not have the named pipe bit set")
+	}
+	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
+	// device.
+	return mknod(path, mode, 0, 0)
 }

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -10,26 +10,19 @@ var (
 )
 
 type hardlinkManager struct {
-	hardlinks map[hardlinkKey][]RegularFile
+	hardlinks map[hardlinkKey][]Resource
 }
 
 func newHardlinkManager() *hardlinkManager {
 	return &hardlinkManager{
-		hardlinks: map[hardlinkKey][]RegularFile{},
+		hardlinks: map[hardlinkKey][]Resource{},
 	}
 }
 
 // Add attempts to add the resource to the hardlink manager. If the resource
 // cannot be considered as a hardlink candidate, errNotAHardLink is returned.
 func (hlm *hardlinkManager) Add(fi os.FileInfo, resource Resource) error {
-	if !fi.Mode().IsRegular() {
-		return errNotAHardLink
-	}
-
-	// TODO(stevvooe): This check is redundant to that above. May want to
-	// tweak our resource model on this basis.
-	regfile, ok := resource.(RegularFile)
-	if !ok {
+	if _, ok := resource.(Hardlinkable); !ok {
 		return errNotAHardLink
 	}
 
@@ -38,7 +31,7 @@ func (hlm *hardlinkManager) Add(fi os.FileInfo, resource Resource) error {
 		return err
 	}
 
-	hlm.hardlinks[key] = append(hlm.hardlinks[key], regfile)
+	hlm.hardlinks[key] = append(hlm.hardlinks[key], resource)
 
 	return nil
 }


### PR DESCRIPTION
Since devices and named pipes can support hard links, this involves
changing the Merge function to support types other than RegularFile.

This also fixes Verify to properly check for hard links. Part of Verify
is split into verifyMetadata. This portion is called for each link, but
digests are only verified on one instance of the inode.