### PR TITLE
Add data interfaces

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package continuity
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -36,6 +37,7 @@ type SymlinkPath func(root, linkname, target string) (string, error)
 type ContextOptions struct {
 	Digester Digester
 	Driver   Driver
+	Provider ContentProvider
 }
 
 // context represents a file system context for accessing resources.
@@ -45,6 +47,7 @@ type context struct {
 	driver   Driver
 	root     string
 	digester Digester
+	provider ContentProvider
 }
 
 // NewContext returns a Context associated with root. The default driver will
@@ -91,6 +94,7 @@ func NewContextWithOptions(root string, options ContextOptions) (Context, error)
 		root:     root,
 		driver:   driver,
 		digester: digester,
+		provider: options.Provider,
 	}, nil
 }
 
@@ -357,6 +361,28 @@ func (c *context) Verify(resource Resource) error {
 	return nil
 }
 
+func (c *context) checkoutFile(fp string, rf RegularFile) error {
+	if c.provider == nil {
+		return fmt.Errorf("no file provider")
+	}
+	var (
+		r   io.ReadCloser
+		err error
+	)
+	for _, dgst := range rf.Digests() {
+		r, err = c.provider.Reader(dgst)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("file content could not be provided: %v", err)
+	}
+	defer r.Close()
+
+	return atomicWriteFile(fp, r, rf)
+}
+
 // Apply the resource to the contexts. An error will be returned if the
 // operation fails. Depending on the resource type, the resource may be
 // created. For resource that cannot be resolved, an error will be returned.
@@ -381,15 +407,40 @@ func (c *context) Apply(resource Resource) error {
 	switch r := resource.(type) {
 	case RegularFile:
 		if fi == nil {
-			return fmt.Errorf("file does not exist %q", resource.Path())
+			if err := c.checkoutFile(fp, r); err != nil {
+				return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+			}
+			chmod = false
+		} else {
+			if !fi.Mode().IsRegular() {
+				return fmt.Errorf("file %q should be a regular file, but is not", resource.Path())
+			}
+			if fi.Size() != r.Size() {
+				if err := c.checkoutFile(fp, r); err != nil {
+					return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+				}
+			} else {
+				for _, dgst := range r.Digests() {
+					f, err := os.Open(fp)
+					if err != nil {
+						return fmt.Errorf("failure opening file for read %q: %v", resource.Path(), err)
+					}
+					compared, err := dgst.Algorithm().FromReader(f)
+					if err == nil && dgst != compared {
+						if err := c.checkoutFile(fp, r); err != nil {
+							return fmt.Errorf("error checking out file %q: %v", resource.Path(), err)
+						}
+						break
+					}
+					if err1 := f.Close(); err == nil {
+						err = err1
+					}
+					if err != nil {
+						return fmt.Errorf("error checking digest for %q: %v", resource.Path(), err)
+					}
+				}
+			}
 		}
-
-		if !fi.Mode().IsRegular() {
-			return fmt.Errorf("file %q should be a regular file, but is not", resource.Path())
-		}
-
-		// TODO(dmcgowan): Verify size and digest
-
 	case Directory:
 		if fi == nil {
 			if err := c.driver.Mkdir(fp, resource.Mode()); err != nil {

--- a/digests.go
+++ b/digests.go
@@ -8,18 +8,18 @@ import (
 	"github.com/docker/distribution/digest"
 )
 
-// digestPath returns the digest of the file at path p. Currently, this only
-// uses the value of digest.Canonical to resolve the hash to use.
-func digestPath(d Driver, p string) (digest.Digest, error) {
-	digester := digest.Canonical.New() // TODO(stevvooe): Make this configurable.
+type Digester interface {
+	Digest(io.Reader) (digest.Digest, error)
+}
 
-	f, err := d.Open(p)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
+type simpleDigester struct {
+	algorithm digest.Algorithm
+}
 
-	if _, err := io.Copy(digester.Hash(), f); err != nil {
+func (sd simpleDigester) Digest(r io.Reader) (digest.Digest, error) {
+	digester := sd.algorithm.New()
+
+	if _, err := io.Copy(digester.Hash(), r); err != nil {
 		return "", err
 	}
 

--- a/digests.go
+++ b/digests.go
@@ -8,8 +8,14 @@ import (
 	"github.com/docker/distribution/digest"
 )
 
+// Digester produces a digest for a given read stream
 type Digester interface {
 	Digest(io.Reader) (digest.Digest, error)
+}
+
+// ContentProvider produces a read stream for a given digest
+type ContentProvider interface {
+	Reader(digest.Digest) (io.ReadCloser, error)
 }
 
 type simpleDigester struct {

--- a/driver_unix.go
+++ b/driver_unix.go
@@ -101,3 +101,7 @@ func (d *driver) LSetxattr(path string, attrMap map[string][]byte) error {
 
 	return nil
 }
+
+func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
+	return deviceInfo(fi)
+}


### PR DESCRIPTION
Add interfaces for a context to be able to use a blob store for storing and fetching content. The continuity interface does not need to expose the concept of the blob store since it is only concerned about bytes and hashes and nothing related to their storage.

This updates the Apply logic to be able to set the content of a file, creating files that do not exist. Currently the apply is still lacking the functionality to completely sync a directory, which could include removing files. It may make sense to split off the currently Apply (just metadata) and Sync (changes content).