### PR TITLE
CI + bunch of fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
+  - 1.7
   - 1.8
 
 go_import_path: github.com/stevvooe/continuity

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.8
+
+go_import_path: github.com/stevvooe/continuity

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ go:
   - 1.8
 
 go_import_path: github.com/stevvooe/continuity
+
+script:
+# TODO: vendor
+  - go get -t ./...
+  - make

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+Aaron Lehmann <aaron.lehmann@docker.com>
+Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Brandon Philips <brandon.philips@coreos.com>
+Derek McGowan <derek@mcgstyle.net>
+Stephen Day <stevvooe@users.noreply.github.com>
+Stephen J Day <stephen.day@docker.com>
+Tonis Tiigi <tonistiigi@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
 .PHONY: clean all fmt vet lint build test binaries setup
 .DEFAULT: default
-all: AUTHORS clean fmt vet fmt lint build test binaries
+# skip lint at the moment
+all: AUTHORS clean fmt vet fmt build test binaries
 
 AUTHORS: .mailmap .git/HEAD
 	 git log --format='%aN <%aE>' | sort -fu > $@
@@ -45,14 +46,15 @@ lint:
 
 build:
 	@echo "+ $@"
-	@go build -tags "${DOCKER_BUILDTAGS}" -v ${GO_LDFLAGS} ./...
+	@go build -v ${GO_LDFLAGS} ./...
 
 test:
 	@echo "+ $@"
-	@go test -tags "${DOCKER_BUILDTAGS}" ./...
+	@go test ./...
 
 binaries: ${PREFIX}/bin/continuity
 	@echo "+ $@"
+	@go build -o $< ${GO_LDFLAGS} ./cmd/continuity
 
 clean:
 	@echo "+ $@"

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ test:
 
 binaries: ${PREFIX}/bin/continuity
 	@echo "+ $@"
-	@go build -o $< ${GO_LDFLAGS} ./cmd/continuity
 
 clean:
 	@echo "+ $@"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # continuity
 
+[![GoDoc](https://godoc.org/github.com/stevvooe/continuity?status.svg)](https://godoc.org/github.com/stevvooe/continuity)
+[![Build Status](https://travis-ci.org/stevvooe/continuity.svg?branch=master)](https://travis-ci.org/stevvooe/continuity)
+
 A transport-agnostic, filesystem metadata manifest system
 
 This project is a staging area for experiments in providing transport agnostic

--- a/digests_test.go
+++ b/digests_test.go
@@ -20,24 +20,24 @@ func TestUniqifyDigests(t *testing.T) {
 		{
 			description: "simple merge",
 			input: [][]digest.Digest{
-				[]digest.Digest{"sha1:abc", "sha256:def"},
-				[]digest.Digest{"sha1:abc", "sha256:def"},
+				{"sha1:abc", "sha256:def"},
+				{"sha1:abc", "sha256:def"},
 			},
 			expected: []digest.Digest{"sha1:abc", "sha256:def"},
 		},
 		{
 			description: "simple reversed order",
 			input: [][]digest.Digest{
-				[]digest.Digest{"sha1:abc", "sha256:def"},
-				[]digest.Digest{"sha256:def", "sha1:abc"},
+				{"sha1:abc", "sha256:def"},
+				{"sha256:def", "sha1:abc"},
 			},
 			expected: []digest.Digest{"sha1:abc", "sha256:def"},
 		},
 		{
 			description: "conflicting values for sha1",
 			input: [][]digest.Digest{
-				[]digest.Digest{"sha1:abc", "sha256:def"},
-				[]digest.Digest{"sha256:def", "sha1:def"},
+				{"sha1:abc", "sha256:def"},
+				{"sha256:def", "sha1:def"},
 			},
 			err: fmt.Errorf("conflicting digests for sha1 found"),
 		},

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -139,7 +139,7 @@ func TestWalkFS(t *testing.T) {
 
 	m, err := BuildManifest(ctx)
 	if err != nil {
-		t.Fatalf("error building manifest: %v, %#T", err, err)
+		t.Fatalf("error building manifest: %v", err)
 	}
 
 	var b bytes.Buffer
@@ -237,7 +237,7 @@ func generateTestFiles(t *testing.T, root string, resources []dresource) {
 			}
 		case rdirectory:
 			if err := os.Mkdir(p, resource.mode); err != nil {
-				t.Fatalf("error creating directory %q: %v", err)
+				t.Fatalf("error creating directory %q: %v", p, err)
 			}
 		case rhardlink:
 			target := filepath.Join(root, resource.target)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -151,7 +151,7 @@ func TestWalkFS(t *testing.T) {
 	//	t.Fatalf("error verifying manifest: %v")
 	//}
 
-	expectedResources, err := expectedResourceList(testResources)
+	expectedResources, err := expectedResourceList(root, testResources)
 	if err != nil {
 		// TODO(dmcgowan): update function to panic, this would mean test setup error
 		t.Fatalf("error creating resource list: %v", err)
@@ -306,7 +306,7 @@ func randomBytes(p []byte) {
 
 // expectedResourceList sorts the set of resources into the order
 // expected in the manifest and collapses hardlinks
-func expectedResourceList(resources []dresource) ([]Resource, error) {
+func expectedResourceList(root string, resources []dresource) ([]Resource, error) {
 	resourceMap := map[string]Resource{}
 	paths := []string{}
 	for _, r := range resources {
@@ -362,7 +362,8 @@ func expectedResourceList(resources []dresource) ([]Resource, error) {
 		case rrelsymlink, rabssymlink:
 			targetPath := r.target
 			if r.kind == rabssymlink && !filepath.IsAbs(r.target) {
-				targetPath = "/" + targetPath
+				// for absolute links, we join with root.
+				targetPath = filepath.Join(root, targetPath)
 			}
 			s := &symLink{
 				resource: resource{

--- a/resource.go
+++ b/resource.go
@@ -111,7 +111,7 @@ func Merge(fs ...Resource) (Resource, error) {
 		if xattrer, ok := f.(XAttrer); ok {
 			fxattrs := xattrer.XAttrs()
 			if !reflect.DeepEqual(fxattrs, xattrs) {
-				return nil, fmt.Errorf("resource %q xattrs do not match: %v != %v", fxattrs, xattrs)
+				return nil, fmt.Errorf("resource %q xattrs do not match: %v != %v", f, fxattrs, xattrs)
 			}
 		}
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,156 @@
+package continuity
+
+type resourceUpdate struct {
+	Original Resource
+	Updated  Resource
+}
+
+type resourceListDifference struct {
+	Additions []Resource
+	Deletions []Resource
+	Updates   []resourceUpdate
+}
+
+func (l resourceListDifference) HasDiff() bool {
+	return len(l.Additions) > 0 || len(l.Deletions) > 0 || len(l.Updates) > 0
+}
+
+// diffManifest compares two resource lists and returns the list
+// of adds updates and deletes, resource lists are not reordered
+// before doing difference.
+func diffResourceList(r1, r2 []Resource) resourceListDifference {
+	i1 := 0
+	i2 := 0
+	var d resourceListDifference
+
+	for i1 < len(r1) && i2 < len(r2) {
+		p1 := r1[i1].Path()
+		p2 := r2[i2].Path()
+		switch {
+		case p1 < p2:
+			d.Deletions = append(d.Deletions, r1[i1])
+			i1++
+		case p1 == p2:
+			if !compareResource(r1[i1], r2[i2]) {
+				d.Updates = append(d.Updates, resourceUpdate{
+					Original: r1[i1],
+					Updated:  r2[i2],
+				})
+			}
+			i1++
+			i2++
+		case p1 > p2:
+			d.Additions = append(d.Additions, r2[i2])
+			i2++
+		}
+	}
+
+	for i1 < len(r1) {
+		d.Deletions = append(d.Deletions, r1[i1])
+		i1++
+
+	}
+	for i2 < len(r2) {
+		d.Additions = append(d.Additions, r2[i2])
+		i2++
+	}
+
+	return d
+}
+
+func compareResource(r1, r2 Resource) bool {
+	if r1.Path() != r2.Path() {
+		return false
+	}
+	if r1.Mode() != r2.Mode() {
+		return false
+	}
+	if r1.UID() != r2.UID() {
+		return false
+	}
+	if r1.GID() != r2.GID() {
+		return false
+	}
+
+	// TODO(dmcgowan): Check if is XAttrer
+
+	switch t1 := r1.(type) {
+	case RegularFile:
+		t2, ok := r2.(RegularFile)
+		if !ok {
+			return false
+		}
+		return compareRegularFile(t1, t2)
+	case Directory:
+		t2, ok := r2.(Directory)
+		if !ok {
+			return false
+		}
+		return compareDirectory(t1, t2)
+	case SymLink:
+		t2, ok := r2.(SymLink)
+		if !ok {
+			return false
+		}
+		return compareSymLink(t1, t2)
+	case NamedPipe:
+		t2, ok := r2.(NamedPipe)
+		if !ok {
+			return false
+		}
+		return compareNamedPipe(t1, t2)
+	case Device:
+		t2, ok := r2.(Device)
+		if !ok {
+			return false
+		}
+		return compareDevice(t1, t2)
+	default:
+		// TODO(dmcgowan): Should this panic?
+		return r1 == r2
+	}
+}
+
+func compareRegularFile(r1, r2 RegularFile) bool {
+	if r1.Size() != r2.Size() {
+		return false
+	}
+	p1 := r1.Paths()
+	p2 := r2.Paths()
+	if len(p1) != len(p2) {
+		return false
+	}
+	for i := range p1 {
+		if p1[i] != p2[i] {
+			return false
+		}
+	}
+	d1 := r1.Digests()
+	d2 := r2.Digests()
+	if len(d1) != len(d2) {
+		return false
+	}
+	for i := range d1 {
+		if d1[i] != d2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareSymLink(r1, r2 SymLink) bool {
+	return r1.Target() == r2.Target()
+}
+
+func compareDirectory(r1, r2 Directory) bool {
+	return true
+}
+
+func compareNamedPipe(r1, r2 NamedPipe) bool {
+	return true
+}
+
+func compareDevice(r1, r2 Device) bool {
+	return r1.Major() == r2.Major() && r1.Minor() == r2.Minor()
+}

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,53 @@
+package continuity
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func tree(w io.Writer, dir string) error {
+	fmt.Fprintf(w, "%s\n", dir)
+	return _tree(w, dir, "")
+}
+
+func _tree(w io.Writer, dir string, indent string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for i, f := range files {
+		fPath := filepath.Join(dir, f.Name())
+		fIndent := indent
+		if i < len(files)-1 {
+			fIndent += "|-- "
+		} else {
+			fIndent += "`-- "
+		}
+		target := ""
+		if f.Mode()&os.ModeSymlink == os.ModeSymlink {
+			realPath, err := os.Readlink(fPath)
+			if err != nil {
+				target += fmt.Sprintf(" -> unknown (error: %v)", err)
+			} else {
+				target += " -> " + realPath
+			}
+		}
+		fmt.Fprintf(w, "%s%s%s\n",
+			fIndent, f.Name(), target)
+		if f.IsDir() {
+			dIndent := indent
+			if i < len(files)-1 {
+				dIndent += "|   "
+			} else {
+				dIndent += "    "
+			}
+			if err := _tree(w, fPath, dIndent); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION

#### `.travis.yml`:
- Newly added (Fix #40, let me know if you prefer other CI :smile:)

#### `.mailmap`, `AUTHORS`, `Makefile`:
- Fix `make AUTHORS`, which was broken because of lack of `.mailmap` (I can remove this target if unneeded)
- Skip running lint by default because it is too noisy about "comments are missing"
- Remove wrong `${DOCKER_BUILDTAGS}`
- Fix `make binaries`, which was just an empty target

#### `README.md`: 
- Add godoc badge and travis badge

#### `digests_test.go`, `resource.go`: 
- Fix for `go vet`

#### `manifest_test.go`, `resource_test.go`, `testutil_test.go`:
- Add missing `diffResourceList()` from #39 (@dmcgowan)
- Remove dependency for `tree(1)`
- Fix for `go vet`
- Fix the following test failure;
```
manifest_test.go:163: Resource list difference
manifest_test.go:171: Changed resource:
                    Expected: &continuity.symLink{resource:continuity.resource{paths:[]string{"/c/a-abssymlink"}, mode:0x80001ff, uid:"1001", gid:"100
1", xattrs:map[string][]uint8(nil)}, target:"/a"}
                    Actual:   &continuity.symLink{resource:continuity.resource{paths:[]string{"/c/a-abssymlink"}, mode:0x80001ff, uid:"1001", gid:"100
1", xattrs:map[string][]uint8{}}, target:"/tmp/continuity-test-356664233/a"}
    
```

Now CI passing: https://travis-ci.org/AkihiroSuda/continuity/builds/208498783

I'm also planning to do vendor using vndr in another PR.
