### PR TITLE
Fix apply on non-existent symlink

### DIFF
--- a/context.go
+++ b/context.go
@@ -463,8 +463,10 @@ func (c *context) Apply(resource Resource) error {
 		}
 
 		if target != r.Target() {
-			if err := c.driver.Remove(fp); err != nil { // RemoveAll?
-				return err
+			if fi != nil {
+				if err := c.driver.Remove(fp); err != nil { // RemoveAll in case of directory?
+					return err
+				}
 			}
 
 			if err := c.driver.Symlink(r.Target(), fp); err != nil {


### PR DESCRIPTION
When applying a symlink, skip removal if the file does not exist. This fixes a bug where apply was failing when the file did not already exist.