### PR TITLE
Separate windows and unix code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
 
 go_import_path: github.com/stevvooe/continuity
 
+env:
+  - GOOS=windows
+  - GOOS=linux
+
 script:
 # TODO: vendor
   - go get -t ./...

--- a/context.go
+++ b/context.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/opencontainers/go-digest"
 )
@@ -115,19 +114,7 @@ func (c *context) Resource(p string, fi os.FileInfo) (Resource, error) {
 		}
 	}
 
-	// TODO(stevvooe): This need to be resolved for the container's root,
-	// where here we are really getting the host OS's value. We need to allow
-	// this be passed in and fixed up to make these uid/gid mappings portable.
-	// Either this can be part of the driver or we can achieve it through some
-	// other mechanism.
-	sys, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		// TODO(stevvooe): This may not be a hard error for all platforms. We
-		// may want to move this to the driver.
-		return nil, fmt.Errorf("unable to resolve syscall.Stat_t from (os.FileInfo).Sys(): %#v", fi)
-	}
-
-	base, err := newBaseResource(p, fi.Mode(), fmt.Sprint(sys.Uid), fmt.Sprint(sys.Gid))
+	base, err := newBaseResource(p, fi)
 	if err != nil {
 		return nil, err
 	}

--- a/devices_windows.go
+++ b/devices_windows.go
@@ -1,0 +1,11 @@
+package continuity
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func deviceInfo(fi os.FileInfo) (uint64, uint64, error) {
+	return 0, 0, errors.Wrap(ErrNotSupported, "cannot get device info on windows")
+}

--- a/driver.go
+++ b/driver.go
@@ -1,7 +1,6 @@
 package continuity
 
 import (
-	"errors"
 	"os"
 	"strconv"
 )
@@ -142,17 +141,4 @@ func (d *driver) Lchown(name, uidStr, gidStr string) error {
 
 func (d *driver) Symlink(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
-}
-
-func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
-	return mknod(path, mode, major, minor)
-}
-
-func (d *driver) Mkfifo(path string, mode os.FileMode) error {
-	if mode&os.ModeNamedPipe == 0 {
-		return errors.New("mode passed to Mkfifo does not have the named pipe bit set")
-	}
-	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
-	// device.
-	return mknod(path, mode, 0, 0)
 }

--- a/driver_unix.go
+++ b/driver_unix.go
@@ -3,6 +3,7 @@
 package continuity
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,19 @@ import (
 
 	"github.com/stevvooe/continuity/sysx"
 )
+
+func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
+	return mknod(path, mode, major, minor)
+}
+
+func (d *driver) Mkfifo(path string, mode os.FileMode) error {
+	if mode&os.ModeNamedPipe == 0 {
+		return errors.New("mode passed to Mkfifo does not have the named pipe bit set")
+	}
+	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
+	// device.
+	return mknod(path, mode, 0, 0)
+}
 
 // Lchmod changes the mode of an file not following symlinks.
 func (d *driver) Lchmod(path string, mode os.FileMode) (err error) {

--- a/driver_windows.go
+++ b/driver_windows.go
@@ -1,0 +1,21 @@
+package continuity
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
+	return errors.Wrap(ErrNotSupported, "cannot create device node on Windows")
+}
+
+func (d *driver) Mkfifo(path string, mode os.FileMode) error {
+	return errors.Wrap(ErrNotSupported, "cannot create fifo on Windows")
+}
+
+// Lchmod changes the mode of an file not following symlinks.
+func (d *driver) Lchmod(path string, mode os.FileMode) (err error) {
+	// TODO: Use Window's equivalent
+	return os.Chmod(path, mode)
+}

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package continuity
 
 import (

--- a/hardlinks_windows.go
+++ b/hardlinks_windows.go
@@ -1,5 +1,12 @@
 package continuity
 
-// NOTE(stevvooe): Obviously, this is not yet implemented. However, the
-// makings of an implementation are available in src/os/types_windows.go. More
-// investigation needs to be done to figure out exactly how to do this.
+import "os"
+
+type hardlinkKey struct{}
+
+func newHardlinkKey(fi os.FileInfo) (hardlinkKey, error) {
+	// NOTE(stevvooe): Obviously, this is not yet implemented. However, the
+	// makings of an implementation are available in src/os/types_windows.go. More
+	// investigation needs to be done to figure out exactly how to do this.
+	return hardlinkKey{}, errNotAHardLink
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package continuity
 
 import (

--- a/resource_unix.go
+++ b/resource_unix.go
@@ -1,0 +1,37 @@
+// +build linux darwin
+
+package continuity
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// newBaseResource returns a *resource, populated with data from p and fi,
+// where p will be populated directly.
+func newBaseResource(p string, fi os.FileInfo) (*resource, error) {
+	// TODO(stevvooe): This need to be resolved for the container's root,
+	// where here we are really getting the host OS's value. We need to allow
+	// this be passed in and fixed up to make these uid/gid mappings portable.
+	// Either this can be part of the driver or we can achieve it through some
+	// other mechanism.
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		// TODO(stevvooe): This may not be a hard error for all platforms. We
+		// may want to move this to the driver.
+		return nil, fmt.Errorf("unable to resolve syscall.Stat_t from (os.FileInfo).Sys(): %#v", fi)
+	}
+
+	return &resource{
+		paths: []string{p},
+		mode:  fi.Mode(),
+
+		uid: fmt.Sprint(sys.Uid),
+		gid: fmt.Sprint(sys.Gid),
+
+		// NOTE(stevvooe): Population of shared xattrs field is deferred to
+		// the resource types that populate it. Since they are a property of
+		// the context, they must set there.
+	}, nil
+}

--- a/resource_windows.go
+++ b/resource_windows.go
@@ -1,0 +1,12 @@
+package continuity
+
+import "os"
+
+// newBaseResource returns a *resource, populated with data from p and fi,
+// where p will be populated directly.
+func newBaseResource(p string, fi os.FileInfo) (*resource, error) {
+	return &resource{
+		paths: []string{p},
+		mode:  fi.Mode(),
+	}, nil
+}


### PR DESCRIPTION
Move unix specific code to unix only build files. Add stub implementation for Windows where needed. Remove syscall importing from platform-agnostic files.

This isn't perfect but support for devices and symlinks on Windows is still unclear to me. Also does not appear that there is any equivalent of UID and GID to set.