### PR TITLE
Compile on Windows

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/opencontainers/go-digest"
 )
@@ -115,19 +114,12 @@ func (c *context) Resource(p string, fi os.FileInfo) (Resource, error) {
 		}
 	}
 
-	// TODO(stevvooe): This need to be resolved for the container's root,
-	// where here we are really getting the host OS's value. We need to allow
-	// this be passed in and fixed up to make these uid/gid mappings portable.
-	// Either this can be part of the driver or we can achieve it through some
-	// other mechanism.
-	sys, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		// TODO(stevvooe): This may not be a hard error for all platforms. We
-		// may want to move this to the driver.
-		return nil, fmt.Errorf("unable to resolve syscall.Stat_t from (os.FileInfo).Sys(): %#v", fi)
+	uid, gid, err := getUidGidFromFileInfo(fi)
+	if err != nil {
+		return nil, err
 	}
 
-	base, err := newBaseResource(p, fi.Mode(), fmt.Sprint(sys.Uid), fmt.Sprint(sys.Gid))
+	base, err := newBaseResource(p, fi.Mode(), fmt.Sprint(uid), fmt.Sprint(gid))
 	if err != nil {
 		return nil, err
 	}

--- a/context_unix.go
+++ b/context_unix.go
@@ -1,0 +1,26 @@
+// +build linux darwin
+
+package continuity
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// getUidGidFromFileInfo extracts the user and group IDs from a fileinfo.
+// This is Unix-specific functionality.
+func getUidGidFromFileInfo(fi os.FileInfo) (uint32, uint32, error) {
+	// TODO(stevvooe): This need to be resolved for the container's root,
+	// where here we are really getting the host OS's value. We need to allow
+	// this be passed in and fixed up to make these uid/gid mappings portable.
+	// Either this can be part of the driver or we can achieve it through some
+	// other mechanism.
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		// TODO(stevvooe): This may not be a hard error for all platforms. We
+		// may want to move this to the driver.
+		return 0, 0, fmt.Errorf("unable to resolve syscall.Stat_t from (os.FileInfo).Sys(): %#v", fi)
+	}
+	return sys.Uid, sys.Gid, nil
+}

--- a/context_windows.go
+++ b/context_windows.go
@@ -1,0 +1,9 @@
+package continuity
+
+import "os"
+
+// getUidGidFromFileInfo extracts the user and group IDs from a fileinfo.
+// This is Unix-specific functionality.
+func getUidGidFromFileInfo(fi os.FileInfo) (uint32, uint32, error) {
+	return 0, 0, nil
+}

--- a/driver.go
+++ b/driver.go
@@ -1,7 +1,6 @@
 package continuity
 
 import (
-	"errors"
 	"os"
 	"strconv"
 )
@@ -144,15 +143,6 @@ func (d *driver) Symlink(oldname, newname string) error {
 	return os.Symlink(oldname, newname)
 }
 
-func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
-	return mknod(path, mode, major, minor)
-}
-
-func (d *driver) Mkfifo(path string, mode os.FileMode) error {
-	if mode&os.ModeNamedPipe == 0 {
-		return errors.New("mode passed to Mkfifo does not have the named pipe bit set")
-	}
-	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
-	// device.
-	return mknod(path, mode, 0, 0)
+func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
+	return deviceInfo(fi)
 }

--- a/driver_darwin.go
+++ b/driver_darwin.go
@@ -1,7 +1,0 @@
-package continuity
-
-import "os"
-
-func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
-	return deviceInfo(fi)
-}

--- a/driver_unix.go
+++ b/driver_unix.go
@@ -3,6 +3,7 @@
 package continuity
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -102,6 +103,15 @@ func (d *driver) LSetxattr(path string, attrMap map[string][]byte) error {
 	return nil
 }
 
-func (d *driver) DeviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
-	return deviceInfo(fi)
+func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
+	return mknod(path, mode, major, minor)
+}
+
+func (d *driver) Mkfifo(path string, mode os.FileMode) error {
+	if mode&os.ModeNamedPipe == 0 {
+		return errors.New("mode passed to Mkfifo does not have the named pipe bit set")
+	}
+	// mknod with a mode that has ModeNamedPipe set creates a fifo, not a
+	// device.
+	return mknod(path, mode, 0, 0)
 }

--- a/driver_windows.go
+++ b/driver_windows.go
@@ -1,0 +1,30 @@
+package continuity
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	errdeviceInfoNotImplemented = fmt.Errorf("deviceInfo not implemented on Windows")
+	errLchmodNotImplemented     = fmt.Errorf("Lchmod not implemented on Windows")
+	errMknodNotImplemented      = fmt.Errorf("Mknod not implemented on Windows")
+	errMkfifoNotImplemented     = fmt.Errorf("Mkfifo not implemented on Windows")
+)
+
+func deviceInfo(fi os.FileInfo) (maj uint64, min uint64, err error) {
+	return 0, 0, errdeviceInfoNotImplemented
+}
+
+// Lchmod changes the mode of an file not following symlinks.
+func (d *driver) Lchmod(path string, mode os.FileMode) (err error) {
+	return errLchmodNotImplemented
+}
+
+func (d *driver) Mknod(path string, mode os.FileMode, major, minor int) error {
+	return errMknodNotImplemented
+}
+
+func (d *driver) Mkfifo(path string, mode os.FileMode) error {
+	return errMkfifoNotImplemented
+}

--- a/groups_unix.go
+++ b/groups_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package continuity
 
 import (

--- a/hardlinks.go
+++ b/hardlinks.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	errNotAHardLink = fmt.Errorf("invalid hardlink")
+	errNotAHardLink           = fmt.Errorf("invalid hardlink")
+	errNotHardLinkImplemented = fmt.Errorf("hardlink not implemented")
 )
 
 type hardlinkManager struct {

--- a/hardlinks_unix.go
+++ b/hardlinks_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package continuity
 
 import (

--- a/hardlinks_windows.go
+++ b/hardlinks_windows.go
@@ -1,5 +1,19 @@
 package continuity
 
+import "os"
+
 // NOTE(stevvooe): Obviously, this is not yet implemented. However, the
 // makings of an implementation are available in src/os/types_windows.go. More
 // investigation needs to be done to figure out exactly how to do this.
+
+// hardlinkKey provides a tuple-key for managing hardlinks. This is system-
+// specific.
+type hardlinkKey struct {
+}
+
+// newHardlinkKey returns a hardlink key for the provided file info. If the
+// resource does not represent a possible hardlink, errNotAHardLink will be
+// returned.
+func newHardlinkKey(fi os.FileInfo) (hardlinkKey, error) {
+	return hardlinkKey{}, errNotHardLinkImplemented
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"syscall"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -267,8 +266,13 @@ func generateTestFiles(t *testing.T, root string, resources []dresource) {
 		if err != nil {
 			t.Fatalf("error statting after creation: %v", err)
 		}
-		resources[i].uid = int(st.Sys().(*syscall.Stat_t).Uid)
-		resources[i].gid = int(st.Sys().(*syscall.Stat_t).Gid)
+
+		uid, gid, err := getUidGidFromFileInfo(st)
+		if err != nil {
+			t.Fatalf("error getting Uid/Gid: %v", err)
+		}
+		resources[i].uid = int(uid)
+		resources[i].gid = int(gid)
 		resources[i].mode = st.Mode()
 
 		// TODO: Readback and join xattr

--- a/resource.go
+++ b/resource.go
@@ -528,7 +528,7 @@ func fromProto(b *pb.Resource) (Resource, error) {
 
 	base.xattrs = make(map[string][]byte, len(b.Xattr))
 
-	for _, attr:= range b.Xattr {
+	for _, attr := range b.Xattr {
 		base.xattrs[attr.Name] = attr.Data
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@stevvooe @dmcgowan 

I need this to compile cleanly on Windows for containerd.  Fixups only - I don't know how functional it is yet. Verified it builds clean for `windows`, `darwin` and `linux`

```
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> $env:GOOS="windows"
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> go build
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> $env:GOOS="linux"
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> go build
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> $env:GOOS="darwin"
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]> go build
E:\go\src\github.com\stevvooe\continuity [compile-on-windows]>
```

And verified unit tests pass on Linux:

```
jhoward@jhoward-z420:[/mnt/e/go/src/github.com/stevvooe/continuity]: $ go test -v
=== RUN   TestUniqifyDigests
--- PASS: TestUniqifyDigests (0.00s)
=== RUN   TestWalkFS
--- PASS: TestWalkFS (0.34s)
        manifest_test.go:291: drwx------ /tmp/continuity-test-282077333
        manifest_test.go:291: -rw-r--r-- /tmp/continuity-test-282077333/a
        manifest_test.go:291: -rw-r--r-- /tmp/continuity-test-282077333/a-hardlink
        manifest_test.go:291: drwxr-xr-x /tmp/continuity-test-282077333/b
        manifest_test.go:291: trw------- /tmp/continuity-test-282077333/b/a
        manifest_test.go:291: -rw-r--r-- /tmp/continuity-test-282077333/b/a-hardlink
        manifest_test.go:291: drwxr-xr-x /tmp/continuity-test-282077333/c
        manifest_test.go:291: -rw-r--r-- /tmp/continuity-test-282077333/c/a
        manifest_test.go:289: Lrwxrwxrwx /tmp/continuity-test-282077333/c/a-abssymlink -> /tmp/continuity-test-282077333/a
        manifest_test.go:289: Lrwxrwxrwx /tmp/continuity-test-282077333/c/a-relsymlink -> ../a
        manifest_test.go:289: Lrwxrwxrwx /tmp/continuity-test-282077333/c/ca-relsymlink -> a
        manifest_test.go:291: drwxr-xr-x /tmp/continuity-test-282077333/dev
        manifest_test.go:291: prw-rw-rw- /tmp/continuity-test-282077333/fifo
        manifest_test.go:303:
                /tmp/continuity-test-282077333
                |-- a
                |-- a-hardlink
                |-- b
                |   |-- a
                |   `-- a-hardlink
                |-- c
                |   |-- a
                |   |-- a-abssymlink -> /tmp/continuity-test-282077333/a
                |   |-- a-relsymlink -> ../a
                |   `-- ca-relsymlink -> a
                |-- dev
                `-- fifo
        manifest_test.go:146: resource: <
                  path: "/a"
                  path: "/a-hardlink"
                  path: "/b/a-hardlink"
                  uid: "1000"
                  gid: "1000"
                  mode: 420
                  size: 2458145
                  digest: "sha256:7fc322fdc391b682d92cd446c437de5b68b921f63546e57677b6dde20c69338a"
                >
                resource: <
                  path: "/b"
                  uid: "1000"
                  gid: "1000"
                  mode: 2147484141
                >
                resource: <
                  path: "/b/a"
                  uid: "1000"
                  gid: "1000"
                  mode: 1048960
                  size: 2725329
                  digest: "sha256:c14fd9031d44df50744fee6d893bff8609212962903971823d3a24b27aa2b872"
                >
                resource: <
                  path: "/c"
                  uid: "1000"
                  gid: "1000"
                  mode: 2147484141
                >
                resource: <
                  path: "/c/a"
                  uid: "1000"
                  gid: "1000"
                  mode: 420
                  size: 573728
                  digest: "sha256:e75dcb2e1625dcb0a80015e79d8e59fb05b42df29bd2460461a7ae3b2dc3cfd8"
                >
                resource: <
                  path: "/c/a-abssymlink"
                  uid: "1000"
                  gid: "1000"
                  mode: 134218239
                  target: "/tmp/continuity-test-282077333/a"
                >
                resource: <
                  path: "/c/a-relsymlink"
                  uid: "1000"
                  gid: "1000"
                  mode: 134218239
                  target: "../a"
                >
                resource: <
                  path: "/c/ca-relsymlink"
                  uid: "1000"
                  gid: "1000"
                  mode: 134218239
                  target: "a"
                >
                resource: <
                  path: "/dev"
                  uid: "1000"
                  gid: "1000"
                  mode: 2147484141
                >
                resource: <
                  path: "/fifo"
                  uid: "1000"
                  gid: "1000"
                  mode: 33554870
                >

PASS
ok      github.com/stevvooe/continuity  0.429s
jhoward@jhoward-z420:[/mnt/e/go/src/github.com/stevvooe/continuity]: $

```


Note that the unit tests have not been ported to Windows yet and don't pass.